### PR TITLE
PR to strip timezone information from CSV download

### DIFF
--- a/hashtagsv2/hashtags/views.py
+++ b/hashtagsv2/hashtags/views.py
@@ -82,7 +82,7 @@ def csv_download(request):
     writer.writerow(['Domain', 'Timestamp', 'Username',
         'Page title', 'Edit summary', 'Recent changes id'])
     for hashtag in hashtags:
-        writer.writerow([hashtag.domain, hashtag.timestamp, hashtag.username,
+        writer.writerow([hashtag.domain, hashtag.timestamp.strftime("%Y-%m-%d %H:%M:%S"), hashtag.username,
             hashtag.page_title, hashtag.edit_summary, hashtag.rc_id])
 
     return response


### PR DESCRIPTION
When we download CSVs from the tool the timestamp includes time zone, which means every field finishes with "+00:00". We should just strip that info and print a naive timestamp.

Phabricator task: T215034