### PR TITLE
Display a notice if database is significantly behind current time

### DIFF
--- a/hashtagsv2/hashtags/views.py
+++ b/hashtagsv2/hashtags/views.py
@@ -1,5 +1,5 @@
 import csv
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from django.contrib import messages
 from django.http import HttpResponse, JsonResponse
@@ -63,6 +63,12 @@ class Index(ListView):
                 if hashtag_qs.count() == 0:
                     messages.add_message(self.request, messages.INFO,
                         'No results found.')
+                else:
+                    latest_datetime = Hashtag.objects.latest('timestamp').timestamp
+                    diff = datetime.now(timezone.utc) - latest_datetime
+                    if diff.seconds > 3600:
+                        messages.add_message(self.request, messages.INFO,
+                        'Note that the latest edits may not be reflected in the tool.')                     
 
             return hashtag_qs
 

--- a/hashtagsv2/hashtags/views.py
+++ b/hashtagsv2/hashtags/views.py
@@ -18,6 +18,12 @@ class Index(ListView):
     paginate_by = 20
 
     def get_context_data(self, *args, **kwargs):
+        latest_datetime = Hashtag.objects.latest('timestamp').timestamp
+        diff = datetime.now(timezone.utc) - latest_datetime
+        if diff.seconds > 3600:
+            messages.add_message(self.request, messages.INFO,
+            'Note that the latest edits may not currently be reflected in the tool.')
+
         context = super().get_context_data(**kwargs)
 
         top_tags = Hashtag.objects.filter(
@@ -62,13 +68,7 @@ class Index(ListView):
 
                 if hashtag_qs.count() == 0:
                     messages.add_message(self.request, messages.INFO,
-                        'No results found.')
-                else:
-                    latest_datetime = Hashtag.objects.latest('timestamp').timestamp
-                    diff = datetime.now(timezone.utc) - latest_datetime
-                    if diff.seconds > 3600:
-                        messages.add_message(self.request, messages.INFO,
-                        'Note that the latest edits may not be reflected in the tool.')                     
+                        'No results found.')                     
 
             return hashtag_qs
 


### PR DESCRIPTION
We check the most recent timestamp in the database and if it's more than 1 hour back from the current time, we display a notice to the user.

Phabricator task: T216727