### PR TITLE
Enable and/or searching

### DIFF
--- a/hashtagsv2/hashtags/forms.py
+++ b/hashtagsv2/hashtags/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 
+TYPE_CHOICES = [('or', 'or'), ('and', 'and')]
+
 class DateInput(forms.DateInput):
 	# Creating a custom widget because default DateInput doesn't use
 	# input type="date"
@@ -9,6 +11,9 @@ class SearchForm(forms.Form):
 	query = forms.CharField(label="Hashtag",
 		widget=forms.TextInput(attrs={'placeholder': 'Enter a hashtag',
 			'style': 'width:100%'}))
+
+	type = forms.CharField(label="Type",
+		widget=forms.Select(choices=TYPE_CHOICES))
 
 	project = forms.CharField(required=False,label="Project",
 		widget=forms.TextInput(attrs={'placeholder': 'en.wikisource.org',

--- a/hashtagsv2/hashtags/forms.py
+++ b/hashtagsv2/hashtags/forms.py
@@ -12,7 +12,7 @@ class SearchForm(forms.Form):
 		widget=forms.TextInput(attrs={'placeholder': 'Enter a hashtag',
 			'style': 'width:100%'}))
 
-	search_type = forms.CharField(label="Type:",
+	search_type = forms.CharField(label="Type:", required=False,
 		widget=forms.Select(choices=TYPE_CHOICES))
 
 	project = forms.CharField(required=False,label="Project",

--- a/hashtagsv2/hashtags/forms.py
+++ b/hashtagsv2/hashtags/forms.py
@@ -12,7 +12,7 @@ class SearchForm(forms.Form):
 		widget=forms.TextInput(attrs={'placeholder': 'Enter a hashtag',
 			'style': 'width:100%'}))
 
-	type = forms.CharField(label="Type",
+	type = forms.CharField(label="Type:",
 		widget=forms.Select(choices=TYPE_CHOICES))
 
 	project = forms.CharField(required=False,label="Project",

--- a/hashtagsv2/hashtags/forms.py
+++ b/hashtagsv2/hashtags/forms.py
@@ -12,7 +12,7 @@ class SearchForm(forms.Form):
 		widget=forms.TextInput(attrs={'placeholder': 'Enter a hashtag',
 			'style': 'width:100%'}))
 
-	type = forms.CharField(label="Type:",
+	search_type = forms.CharField(label="Type:",
 		widget=forms.Select(choices=TYPE_CHOICES))
 
 	project = forms.CharField(required=False,label="Project",

--- a/hashtagsv2/hashtags/helpers.py
+++ b/hashtagsv2/hashtags/helpers.py
@@ -29,7 +29,7 @@ def hashtag_queryset(request_dict):
         selected_rcids = []
         for i in list_of_rcids:
             qs = set(Hashtag.objects.filter(rc_id=i).values_list('hashtag',flat=True).distinct())
-            if qs == set(hashtag_list):
+            if set(hashtag_list).issubset(qs):
                 selected_rcids.append(i)    
         queryset = Hashtag.objects.filter(rc_id__in=selected_rcids)        
 

--- a/hashtagsv2/hashtags/helpers.py
+++ b/hashtagsv2/hashtags/helpers.py
@@ -20,18 +20,19 @@ def hashtag_queryset(request_dict):
 
     hashtag_list = split_hashtags(request_dict['query'])
 
-    if request_dict['type'] == 'or':
-        queryset = Hashtag.objects.filter(
-        hashtag__in=hashtag_list
-            )
-    else:
+    if request_dict['type'] == 'and':
         list_of_rcids = Hashtag.objects.values_list('rc_id',flat=True).distinct()
         selected_rcids = []
         for i in list_of_rcids:
             qs = set(Hashtag.objects.filter(rc_id=i).values_list('hashtag',flat=True).distinct())
             if set(hashtag_list).issubset(qs):
                 selected_rcids.append(i)    
-        queryset = Hashtag.objects.filter(rc_id__in=selected_rcids)        
+        queryset = Hashtag.objects.filter(rc_id__in=selected_rcids)
+
+    else:
+        queryset = Hashtag.objects.filter(
+        hashtag__in=hashtag_list
+            )            
 
     if 'project' in request_dict:
         if request_dict['project']:

--- a/hashtagsv2/hashtags/helpers.py
+++ b/hashtagsv2/hashtags/helpers.py
@@ -20,19 +20,23 @@ def hashtag_queryset(request_dict):
 
     hashtag_list = split_hashtags(request_dict['query'])
 
-    if request_dict['type'] == 'and':
-        list_of_rcids = Hashtag.objects.values_list('rc_id',flat=True).distinct()
-        selected_rcids = []
-        for i in list_of_rcids:
-            qs = set(Hashtag.objects.filter(rc_id=i).values_list('hashtag',flat=True).distinct())
-            if set(hashtag_list).issubset(qs):
-                selected_rcids.append(i)    
-        queryset = Hashtag.objects.filter(rc_id__in=selected_rcids)
-
+    if 'search_type' in request_dict:
+        if request_dict['search_type'] == 'and':
+            rcids_for_hashtag=[]
+            for hashtag in hashtag_list:
+                qs=Hashtag.objects.filter(hashtag=hashtag).values_list('rc_id', flat=True).distinct()
+                rcids_for_hashtag.append(set(qs))
+            final_rcids = rcids_for_hashtag[0].intersection(*rcids_for_hashtag)
+            queryset = Hashtag.objects.filter(rc_id__in=list(final_rcids))
+        
+        else:
+            queryset = Hashtag.objects.filter(
+            hashtag__in=hashtag_list
+            )
     else:
         queryset = Hashtag.objects.filter(
         hashtag__in=hashtag_list
-            )            
+        )
 
     if 'project' in request_dict:
         if request_dict['project']:

--- a/hashtagsv2/hashtags/helpers.py
+++ b/hashtagsv2/hashtags/helpers.py
@@ -25,10 +25,13 @@ def hashtag_queryset(request_dict):
         hashtag__in=hashtag_list
             )
     else:
-        ht_i = Hashtag.objects.filter(hashtag=hashtag_list[0])
-        for ht in hashtag_list:
-            queryset = ht_i.filter(hashtag=ht)
-            ht_i = queryset  
+        list_of_rcids = Hashtag.objects.values_list('rc_id',flat=True).distinct()
+        selected_rcids = []
+        for i in list_of_rcids:
+            qs = set(Hashtag.objects.filter(rc_id=i).values_list('hashtag',flat=True).distinct())
+            if qs == set(hashtag_list):
+                selected_rcids.append(i)    
+        queryset = Hashtag.objects.filter(rc_id__in=selected_rcids)        
 
     if 'project' in request_dict:
         if request_dict['project']:

--- a/hashtagsv2/hashtags/helpers.py
+++ b/hashtagsv2/hashtags/helpers.py
@@ -20,19 +20,24 @@ def hashtag_queryset(request_dict):
 
     hashtag_list = split_hashtags(request_dict['query'])
 
+    # If search_type is provided by the user
     if 'search_type' in request_dict:
         if request_dict['search_type'] == 'and':
             rcids_for_hashtag=[]
+            #Collect rc_ids for each individual tag
             for hashtag in hashtag_list:
                 qs=Hashtag.objects.filter(hashtag=hashtag).values_list('rc_id', flat=True).distinct()
                 rcids_for_hashtag.append(set(qs))
+            #Find common rc_ids by taking intersection of above obtained rc_ids 
             final_rcids = rcids_for_hashtag[0].intersection(*rcids_for_hashtag)
             queryset = Hashtag.objects.filter(rc_id__in=list(final_rcids))
-        
+ 
         else:
             queryset = Hashtag.objects.filter(
             hashtag__in=hashtag_list
             )
+
+    # If user didn't provide search_type
     else:
         queryset = Hashtag.objects.filter(
         hashtag__in=hashtag_list

--- a/hashtagsv2/hashtags/helpers.py
+++ b/hashtagsv2/hashtags/helpers.py
@@ -20,9 +20,15 @@ def hashtag_queryset(request_dict):
 
     hashtag_list = split_hashtags(request_dict['query'])
 
-    queryset = Hashtag.objects.filter(
+    if request_dict['type'] == 'or':
+        queryset = Hashtag.objects.filter(
         hashtag__in=hashtag_list
             )
+    else:
+        ht_i = Hashtag.objects.filter(hashtag=hashtag_list[0])
+        for ht in hashtag_list:
+            queryset = ht_i.filter(hashtag=ht)
+            ht_i = queryset  
 
     if 'project' in request_dict:
         if request_dict['project']:

--- a/hashtagsv2/hashtags/templates/hashtags/index.html
+++ b/hashtagsv2/hashtags/templates/hashtags/index.html
@@ -74,9 +74,13 @@
               {{ form.startdate.label }}
               {{ form.startdate }}
             </div>
-            <div class="three columns">
+            <div class="three columns" style="margin-right: 2em">
               {{ form.enddate.label }}
               {{ form.enddate }}
+            </div>
+            <div class="two columns">
+              {{ form.type.label }}
+              {{ form.type }}
             </div>
           </div>
         </form>

--- a/hashtagsv2/hashtags/templates/hashtags/index.html
+++ b/hashtagsv2/hashtags/templates/hashtags/index.html
@@ -29,9 +29,13 @@
                 {{ form.startdate.label }}
                 {{ form.startdate }}
               </div>
-              <div class="three columns">
+              <div class="three columns" style="margin-right: 2em">
                 {{ form.enddate.label }}
                 {{ form.enddate }}
+              </div>
+              <div class="two columns">
+                {{ form.type.label }}
+                {{ form.type }}
               </div>
             </div>
   	        <div class="row">

--- a/hashtagsv2/hashtags/templates/hashtags/index.html
+++ b/hashtagsv2/hashtags/templates/hashtags/index.html
@@ -38,7 +38,7 @@
               <button type="button" onclick="showAdvance()">Advanced search</button>
             </div>
             <div class="row">
-              <div class="two columns" id="adv" style="display:none">
+              <div class="two columns" id="adv" style="display:none" title="When searching for multiple hashtags, should the results be a subset or union?">
                 {{ form.search_type.label }}
                 {{ form.search_type }}
               </div>
@@ -85,6 +85,9 @@
             </div>
           </div>
           <div class="row">
+            <button type="button" onclick="showAdvance()">Advanced search</button>
+          </div>
+          <div class="row" id="adv" style="display:none" title="When searching for multiple hashtags, should the results be a subset or union?">
             <div class="two columns">
               {{ form.search_type.label }}
               {{ form.search_type }}

--- a/hashtagsv2/hashtags/templates/hashtags/index.html
+++ b/hashtagsv2/hashtags/templates/hashtags/index.html
@@ -35,10 +35,10 @@
               </div>
             </div>
             <div class="row">
-              <button type="button" onclick="myFunction()">Advanced search</button>
+              <button type="button" onclick="showAdvance()">Advanced search</button>
             </div>
             <div class="row">
-              <div class="two columns" id="myDIV" style="display:none">
+              <div class="two columns" id="adv" style="display:none">
                 {{ form.search_type.label }}
                 {{ form.search_type }}
               </div>
@@ -180,8 +180,8 @@
     </div>
   </div>
   <script>
-    function myFunction() {
-  var x = document.getElementById("myDIV");
+    function showAdvance() {
+  var x = document.getElementById("adv");
   if (x.style.display === "none") {
     x.style.display = "block";
   } else {

--- a/hashtagsv2/hashtags/templates/hashtags/index.html
+++ b/hashtagsv2/hashtags/templates/hashtags/index.html
@@ -9,7 +9,7 @@
           <div class="info">{{ message }}</div>
         {% endfor %}
     {% endif %}
-    <div cass="row">
+    <div class="row">
       {% comment %} We show a different search bar if there are results vs not. {% endcomment %}
       {% if not hashtags %}
         <div class="eight columns">
@@ -29,13 +29,18 @@
                 {{ form.startdate.label }}
                 {{ form.startdate }}
               </div>
-              <div class="three columns" style="margin-right: 2em">
+              <div class="three columns">
                 {{ form.enddate.label }}
                 {{ form.enddate }}
               </div>
-              <div class="two columns">
-                {{ form.type.label }}
-                {{ form.type }}
+            </div>
+            <div class="row">
+              <button type="button" onclick="myFunction()">Advanced search</button>
+            </div>
+            <div class="row">
+              <div class="two columns" id="myDIV" style="display:none">
+                {{ form.search_type.label }}
+                {{ form.search_type }}
               </div>
             </div>
   	        <div class="row">
@@ -78,9 +83,11 @@
               {{ form.enddate.label }}
               {{ form.enddate }}
             </div>
+          </div>
+          <div class="row">
             <div class="two columns">
-              {{ form.type.label }}
-              {{ form.type }}
+              {{ form.search_type.label }}
+              {{ form.search_type }}
             </div>
           </div>
         </form>
@@ -172,4 +179,14 @@
       <p></p>
     </div>
   </div>
+  <script>
+    function myFunction() {
+  var x = document.getElementById("myDIV");
+  if (x.style.display === "none") {
+    x.style.display = "block";
+  } else {
+    x.style.display = "none";
+  }
+}
+  </script>
 {% endblock content %}


### PR DESCRIPTION
The tool supports searching for multiple hashtags, by entering e.g. HashtagA, HashtagB in the search box. The default behaviour as implemented is for this to return edits which contain either HashtagA or HashtagB. There are times, however, when a user might want to return results that contain HashtagA and HashtagB.

Phabricator Task: T216398