### PR TITLE
Fix tool not logging log actions like image uploads and page moves

### DIFF
--- a/scripts/collect_hashtags.py
+++ b/scripts/collect_hashtags.py
@@ -34,9 +34,9 @@ for event in EventSource(url):
         hashtag_matches = hashtag_match(change['comment'])
         if hashtag_matches and valid_edit(change):
             for hashtag in hashtag_matches:
-                if db.is_duplicate(hashtag, change['revision']['new']):
-                    print("Skipped duplicate {hashtag} (rev_id = {id})".format(
-                        hashtag=hashtag, id=change['revision']['new']))
+                if db.is_duplicate(hashtag, change['id']):
+                    print("Skipped duplicate {hashtag} (rc_id = {id})".format(
+                        hashtag=hashtag, id=change['id']))
 
                 elif valid_hashtag(hashtag):
                     # Check edit_summary length, truncate if necessary

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -37,7 +37,4 @@ def valid_edit(change):
     # Excluding bots, mostly because of IABot. Lots of data, not very useful.
     not_bot = not change['bot']
 
-    # Only consider edits and page creations
-    correct_type = change['type'] in ["edit", "new"]
-
-    return all([project_match, not_bot, correct_type])
+    return all([project_match, not_bot])


### PR DESCRIPTION
Reverting back to checking duplicates against `rc_id` instead of `rev_id`, and if an event has no `rev_id`, save NULL instead. In this way we're still logging things like page moves and image uploads.