### PR TITLE
Update from deprecated mysql-connector

### DIFF
--- a/requirements/django_app.txt
+++ b/requirements/django_app.txt
@@ -1,6 +1,6 @@
 Django==2.1.1
 factory_boy==2.11.1
 mock==2.0.0
-mysql-connector==2.1.6
+mysql-connector-python==8.0.15
 mysqlclient==1.3.13
 sseclient==0.0.19

--- a/requirements/scripts.txt
+++ b/requirements/scripts.txt
@@ -1,2 +1,2 @@
-mysql-connector==2.1.6
+mysql-connector-python==8.0.15
 sseclient==0.0.19


### PR DESCRIPTION
`mysql-connector` is now deprecated in favour of the official `mysql-connector-python`.