### PR TITLE
T239598 : Allow users to customise data granularity for edits over time graph

### DIFF
--- a/hashtagsv2/graphs/templates/graphs/graph.html
+++ b/hashtagsv2/graphs/templates/graphs/graph.html
@@ -160,11 +160,31 @@
         </h1>
     </div>
     <div class="row">
+       <button name="dailyTimeChart" class="view-type" value="daily">
+            {% comment %} Translators: This labels a button to change to daily view. {% endcomment %}
+            {% trans "Daily" %}
+       </button>&emsp;
+       <button name="monthlyTimeChart" class="view-type" value="monthly">
+            {% comment %} Translators: This labels a button to change to monthly view. {% endcomment %}
+            {% trans "Monthly" %}
+        </button>&emsp;
+       <button name="yearlyTimeChart" class="view-type" value="yearly">
+            {% comment %} Translators: This labels a button to change to yearly view. {% endcomment %}
+            {% trans "Yearly" %}
+        </button>
+    </div>
+    <div class="row">
         <div align="center" id="loader3">
             <img type="image/gif" src="{% static 'loader.gif' %}">
         </div>
         <div>
-            <canvas id="timeChart" width="400" height="400"></canvas>
+            <canvas class="timeChart" id="dailyTimeChart" status="not-loaded" width="400" height="400"></canvas>
+        </div>
+        <div>
+            <canvas class="timeChart" id="monthlyTimeChart" status="not-loaded" width="400" height="400"></canvas>
+        </div>
+        <div>
+            <canvas class="timeChart" id="yearlyTimeChart" status="not-loaded" width="400" height="400"></canvas>
         </div>
         <div class="row download-edits">
             <a href="/time_csv/?{{ query_string }}">

--- a/hashtagsv2/graphs/templates/graphs/graph.html
+++ b/hashtagsv2/graphs/templates/graphs/graph.html
@@ -160,18 +160,9 @@
         </h1>
     </div>
     <div class="row">
-       <button name="dailyTimeChart" class="view-type" value="daily">
-            {% comment %} Translators: This labels a button to change to daily view. {% endcomment %}
-            {% trans "Daily" %}
-       </button>&emsp;
-       <button name="monthlyTimeChart" class="view-type" value="monthly">
-            {% comment %} Translators: This labels a button to change to monthly view. {% endcomment %}
-            {% trans "Monthly" %}
-        </button>&emsp;
-       <button name="yearlyTimeChart" class="view-type" value="yearly">
-            {% comment %} Translators: This labels a button to change to yearly view. {% endcomment %}
-            {% trans "Yearly" %}
-        </button>
+       <button name="dailyTimeChart" class="view-type" value="daily">Daily</button>&emsp;
+       <button name="monthlyTimeChart" class="view-type" value="monthly">Monthly</button>&emsp;
+       <button name="yearlyTimeChart" class="view-type" value="yearly">Yearly</button>
     </div>
     <div class="row">
         <div align="center" id="loader3">
@@ -180,37 +171,52 @@
         <div>
             <canvas class="timeChart" id="dailyTimeChart" status="not-loaded" width="400" height="400"></canvas>
         </div>
-        <div>
+         <div>
             <canvas class="timeChart" id="monthlyTimeChart" status="not-loaded" width="400" height="400"></canvas>
         </div>
-        <div>
+         <div>
             <canvas class="timeChart" id="yearlyTimeChart" status="not-loaded" width="400" height="400"></canvas>
         </div>
         <div class="row download-edits">
-            <a href="/time_csv/?{{ query_string }}">
+
+            <a id="dailyTimeChart-csv" class="downloadAnchor">
                 <button>
-                    {% comment %} Translators: This labels a button to download the data in CSV format. {% endcomment %}
+                    {% comment %} Translators: This labels a button to download the daily data in CSV format. {% endcomment %}
                     {% trans "Download CSV" %}
                 </button>
             </a>
-            <a id="dailyTimeChart-url" class="downloadAnchor">
-                <button id="button-dailyTimeChart-url">
-                    {% comment %} Translators: This labels a button to download the data in JPG format. {% endcomment %}
+            <a id="monthlyTimeChart-csv" class="downloadAnchor">
+                <button >
+                    {% comment %} Translators: This labels a button to download the monthly data in CSV format. {% endcomment %}
+                    {% trans "Download CSV" %}
+                </button>
+            </a>
+            <a id="yearlyTimeChart-csv" class="downloadAnchor">
+                <button>
+                    {% comment %} Translators: This labels a button to download the yearly data in CSV format. {% endcomment %}
+                    {% trans "Download CSV" %}
+                </button>
+            </a>
+
+            <a id="dailyTimeChart-jpg" class="downloadAnchor">
+                <button>
+                    {% comment %} Translators: This labels a button to download the daily data in JPG format. {% endcomment %}
                     {% trans "Download JPG" %}
                 </button>
             </a>
-            <a id="monthlyTimeChart-url" class="downloadAnchor">
-                <button id="button-monthlyTimeChart-url">
-                    {% comment %} Translators: This labels a button to download the data in JPG format. {% endcomment %}
+            <a id="monthlyTimeChart-jpg" class="downloadAnchor">
+                <button>
+                    {% comment %} Translators: This labels a button to download the monthly data in JPG format. {% endcomment %}
                     {% trans "Download JPG" %}
                 </button>
             </a>
-            <a id="yearlyTimeChart-url" class="downloadAnchor">
-                <button id="button-yearlyTimeChart-url">
-                    {% comment %} Translators: This labels a button to download the data in JPG format. {% endcomment %}
+            <a id="yearlyTimeChart-jpg" class="downloadAnchor">
+                <button>
+                    {% comment %} Translators: This labels a button to download the yearly data in JPG format. {% endcomment %}
                     {% trans "Download JPG" %}
                 </button>
             </a>
+
         </div>
     </div>
     <hr>

--- a/hashtagsv2/graphs/templates/graphs/graph.html
+++ b/hashtagsv2/graphs/templates/graphs/graph.html
@@ -160,9 +160,9 @@
         </h1>
     </div>
     <div class="row">
-       <button name="dailyTimeChart" class="view-type" value="daily">Daily</button>&emsp;
-       <button name="monthlyTimeChart" class="view-type" value="monthly">Monthly</button>&emsp;
-       <button name="yearlyTimeChart" class="view-type" value="yearly">Yearly</button>
+       <button name="dailyTimeChart" class="view-type">Daily</button>&emsp;
+       <button name="monthlyTimeChart" class="view-type">Monthly</button>&emsp;
+       <button name="yearlyTimeChart" class="view-type">Yearly</button>
     </div>
     <div class="row">
         <div align="center" id="loader3">

--- a/hashtagsv2/graphs/templates/graphs/graph.html
+++ b/hashtagsv2/graphs/templates/graphs/graph.html
@@ -193,8 +193,20 @@
                     {% trans "Download CSV" %}
                 </button>
             </a>
-            <a id="time_url" class="downloadAnchor">
-                <button>
+            <a id="dailyTimeChart-url" class="downloadAnchor">
+                <button id="button-dailyTimeChart-url">
+                    {% comment %} Translators: This labels a button to download the data in JPG format. {% endcomment %}
+                    {% trans "Download JPG" %}
+                </button>
+            </a>
+            <a id="monthlyTimeChart-url" class="downloadAnchor">
+                <button id="button-monthlyTimeChart-url">
+                    {% comment %} Translators: This labels a button to download the data in JPG format. {% endcomment %}
+                    {% trans "Download JPG" %}
+                </button>
+            </a>
+            <a id="yearlyTimeChart-url" class="downloadAnchor">
+                <button id="button-yearlyTimeChart-url">
                     {% comment %} Translators: This labels a button to download the data in JPG format. {% endcomment %}
                     {% trans "Download JPG" %}
                 </button>

--- a/hashtagsv2/graphs/tests.py
+++ b/hashtagsv2/graphs/tests.py
@@ -132,16 +132,48 @@ class StatisticsTest(TestCase):
 		# CSV should contain 4 lines - header plus 3 entries
 		self.assertEqual(len(page_content.splitlines()), 4)
 
-	def test_time_csv_view(self):
+	def test_time_csv_daily_view(self):
 		factory = RequestFactory()
-		
 		data = {
-			'query': 'test_hashtag1'
+			'query': 'test_hashtag1',
+			'view_type': 'dailyTimeChart'
 		}
-		request = factory.get('/time_csv', data)
+		request = factory.get('/time_csv',data)
 		response = views.time_csv(request)
 		page_content = response.content
+		
+		# CSV should contain 5 lines - header plus 4 entries
+		self.assertEqual(len(page_content.splitlines()), 5)
 
+	def test_time_csv_monthly_view(self):
+		for i in range(1,5):
+			HashtagFactory(hashtag='test_hashtag4', rc_id=120+i, timestamp=datetime(2016,i,1+i))
+
+		factory = RequestFactory()
+		data = {
+			'query': 'test_hashtag4',
+			'view_type': 'monthlyTimeChart'
+		}
+		request = factory.get('/time_csv',data)
+		response = views.time_csv(request)
+		page_content = response.content
+		
+		# CSV should contain 5 lines - header plus 4 entries
+		self.assertEqual(len(page_content.splitlines()), 5)
+
+	def test_time_csv_yearly_view(self):
+		for i in range(1,5):
+			HashtagFactory(hashtag='test_hashtag5', rc_id=120+i, timestamp=datetime(2011+i,i,i+3))
+
+		factory = RequestFactory()
+		data = {
+			'query': 'test_hashtag5',
+			'view_type': 'yearlyTimeChart'
+		}
+		request = factory.get('/time_csv',data)
+		response = views.time_csv(request)
+		page_content = response.content
+		
 		# CSV should contain 5 lines - header plus 4 entries
 		self.assertEqual(len(page_content.splitlines()), 5)
 

--- a/hashtagsv2/graphs/views.py
+++ b/hashtagsv2/graphs/views.py
@@ -239,10 +239,16 @@ def time_csv(request):
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename="hashtags_dates.csv"'
     
+    if temp['view_type'] == 'dailyTimeChart':
+    	header = 'Date'
+    elif temp['view_type'] == 'monthlyTimeChart':
+    	header = 'Month'
+    else:
+    	header = 'Year'
     writer = csv.writer(response)
     writer.writerow([
         # Translators: Date on which edit is made.
-        _('Date'),
+        _(header),
         # Translators: Edits done on wikimedia projects.
         _('Edits')])
     for i,j in zip(temp['time_array'],temp['edits_array']):

--- a/hashtagsv2/graphs/views.py
+++ b/hashtagsv2/graphs/views.py
@@ -67,14 +67,17 @@ def time_statistics_data(request):
     date_range = latest_date - earliest_date
     # key value pairs of date unit and number of edits
     time_dic = {}
+    number_of_days = date_range.days
     
     if "view_type" in request_dict:
         view_type = request_dict['view_type']
+        # assigning some value larger than in the if-else conditions
+        number_of_days = 9999 
     else:
         view_type = 'NOTA'
 
     # Split by days
-    if (date_range.days < 90 or view_type == 'daily') and view_type != 'monthly':
+    if number_of_days < 90 or view_type == 'daily':
         view_type = 'dailyTimeChart'
         qs = hashtags.annotate(day = TruncDay('timestamp')).values('day').annotate(edits = Count('rc_id')).order_by()
         
@@ -90,7 +93,7 @@ def time_statistics_data(request):
                 edits_array.append(0)
             earliest_date = earliest_date + timedelta(days=1)
     # Split by months
-    elif (date_range.days >=90 and date_range.days <1095 or view_type == 'monthly') and view_type != 'yearly':
+    elif number_of_days >=90 and number_of_days <1095 or view_type == 'monthly':
         view_type = 'monthlyTimeChart'
         qs = hashtags.annotate(month = TruncMonth('timestamp')).values('month').annotate(edits = Count('rc_id')).order_by()
         for item in qs:

--- a/hashtagsv2/hashtags/static/js/graph.js
+++ b/hashtagsv2/hashtags/static/js/graph.js
@@ -141,9 +141,8 @@ $(".view-type").click(function() {
     if (status == "loaded") {
         show_chart(chart_name);
     } else {
-        var view_type = $(this).attr("value");
         //adding view_type parameter to url
-        extra_url_param = url_param + '&amp;view_type=' + view_type
+        extra_url_param = url_param + '&amp;view_type=' + chart_name
 
         $.ajax({
             url: '/api/time_stats/?' + extra_url_param,

--- a/hashtagsv2/hashtags/static/js/graph.js
+++ b/hashtagsv2/hashtags/static/js/graph.js
@@ -161,21 +161,20 @@ $(".view-type").click(function() {
 
 // shows the required chart and hides oher
 function show_chart(view_type) {
+    //for chart
     $(".timeChart").hide();
     $('#' + view_type).show();
+    // for DOWNLOAD JPG buttons
+    $(".downloadAnchor").hide();
+    $('#'+view_type+'-url').show();
 
     for (var i = 0; i < 3; i++) {
         ($(".view-type")[i]).style.borderStyle = "hidden";
     }
-
     document.getElementsByName(view_type)[0].style.borderStyle = "solid";
 
     var status = $('#' + view_type).attr("status");
-    if (status == 'loaded') {
-        let time_link = document.getElementById(view_type).toDataURL("image/jpeg");
-        document.getElementById("time_url").href = time_link;
-        document.getElementById("time_url").setAttribute('download', 'edits_over_time.jpg');
-    } else {
+    if (status != 'loaded') {
         $('#' + view_type).attr("status", "loaded");
     }
 }
@@ -217,8 +216,8 @@ function draw_chart(data) {
             animation: {
                 onComplete: function() {
                     let time_link = document.getElementById(data['view_type']).toDataURL("image/jpeg");
-                    document.getElementById("time_url").href = time_link;
-                    document.getElementById("time_url").setAttribute('download', 'edits_over_time.jpg');
+                    document.getElementById(data['view_type']+'-url').href = time_link;
+                    document.getElementById(data['view_type']+'-url').setAttribute('download', 'edits_over_time.jpg');
                 }
             }
         }

--- a/hashtagsv2/hashtags/static/js/graph.js
+++ b/hashtagsv2/hashtags/static/js/graph.js
@@ -118,47 +118,109 @@ else{
     })
 }
 
+// calling the edits_over_time API when page loads gives default view_type
 $.ajax({
     url: '/api/time_stats/?' + url_param,
     dataType: 'json',
-    success: function(data){
-        var ctx = document.getElementById('timeChart');
-        var timeChart = new Chart(ctx, {
-            type: 'line',
-            data: {
-                labels: data['time_array'],
-                datasets: [{
-                    label: 'Number of edits',
-                    data: data['edits_array'],
-                    backgroundColor: 'rgba(255, 99, 132, 0.2)',    
-                    borderColor: 'rgba(255, 99, 132, 1)',
-                    borderWidth: 1,
-                    fill: false
-                }]
-            },
-            options: {
-                scales: {
-                    yAxes: [{
-                        ticks: {
-                            beginAtZero: true,
-                            callback: function (value) { if (Number.isInteger(value)) { return value; } }
-                        }
-                    }]
-                },
-                maintainAspectRatio: false,
-                // When chart is rendered, change download and href atribute of anchor 'Download JPG' to allow users to download charts as image
-                // toDataURL function gets url of chart in type of jpeg image
-                animation: { 
-                    onComplete: function(){ 
-                        let time_link = document.getElementById("timeChart").toDataURL("image/jpeg"); 
-                        document.getElementById("time_url").href = time_link; 
-                        document.getElementById("time_url").setAttribute('download', 'edits_over_time.jpg'); 
-                    } 
-                }
-            }
-        });
+    success: function(data) {
+        show_chart(data['view_type']);
+        draw_chart(data);
     },
-    complete: function(){
+    complete: function() {
         $('#loader3').hide();
     }
 })
+
+
+// when user clicks on button to change default view_type
+$(".view-type").click(function() {
+    var chart_name = $(this).attr("name");
+    var status = $('#' + chart_name).attr("status");
+
+    // if chart is loaded previously
+    if (status == "loaded") {
+        show_chart(chart_name);
+    } else {
+        var view_type = $(this).attr("value");
+        //adding view_type parameter to url
+        extra_url_param = url_param + '&amp;view_type=' + view_type
+
+        $.ajax({
+            url: '/api/time_stats/?' + extra_url_param,
+            dataType: 'json',
+            success: function(data) {
+                show_chart(data['view_type']);
+                draw_chart(data);
+            },
+            complete: function() {
+                $('#loader3').hide();
+            }
+        })
+    }
+});
+
+// shows the required chart and hides oher
+function show_chart(view_type) {
+    $(".timeChart").hide();
+    $('#' + view_type).show();
+
+    for (var i = 0; i < 3; i++) {
+        ($(".view-type")[i]).style.borderStyle = "hidden";
+    }
+
+    document.getElementsByName(view_type)[0].style.borderStyle = "solid";
+
+    var status = $('#' + view_type).attr("status");
+    if (status == 'loaded') {
+        let time_link = document.getElementById(view_type).toDataURL("image/jpeg");
+        document.getElementById("time_url").href = time_link;
+        document.getElementById("time_url").setAttribute('download', 'edits_over_time.jpg');
+    } else {
+        $('#' + view_type).attr("status", "loaded");
+    }
+}
+
+// draw the chart from response data
+function draw_chart(data) {
+
+    var ctx = document.getElementById(data['view_type']);
+
+    var timeChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: data['time_array'],
+            datasets: [{
+                label: 'Number of edits',
+                data: data['edits_array'],
+                backgroundColor: 'rgba(255, 99, 132, 0.2)',
+                borderColor: 'rgba(255, 99, 132, 1)',
+                borderWidth: 1,
+                fill: false
+            }]
+        },
+        options: {
+            scales: {
+                yAxes: [{
+                    ticks: {
+                        beginAtZero: true,
+                        callback: function(value) {
+                            if (Number.isInteger(value)) {
+                                return value;
+                            }
+                        }
+                    }
+                }]
+            },
+            maintainAspectRatio: false,
+            // When chart is rendered, change download and href atribute of anchor 'Download JPG' to allow users to download charts as image
+            // toDataURL function gets url of chart in type of jpeg image
+            animation: {
+                onComplete: function() {
+                    let time_link = document.getElementById(data['view_type']).toDataURL("image/jpeg");
+                    document.getElementById("time_url").href = time_link;
+                    document.getElementById("time_url").setAttribute('download', 'edits_over_time.jpg');
+                }
+            }
+        }
+    });
+}

--- a/hashtagsv2/hashtags/static/js/graph.js
+++ b/hashtagsv2/hashtags/static/js/graph.js
@@ -161,18 +161,20 @@ $(".view-type").click(function() {
 
 // shows the required chart and hides oher
 function show_chart(view_type) {
-    //for chart
     $(".timeChart").hide();
     $('#' + view_type).show();
-    // for DOWNLOAD JPG buttons
-    $(".downloadAnchor").hide();
-    $('#'+view_type+'-url').show();
 
+    $(".downloadAnchor").hide();
+    $('#'+view_type+'-jpg').show();
+    $('#'+view_type+'-csv').show();
+
+    
     for (var i = 0; i < 3; i++) {
         ($(".view-type")[i]).style.borderStyle = "hidden";
     }
     document.getElementsByName(view_type)[0].style.borderStyle = "solid";
 
+    
     var status = $('#' + view_type).attr("status");
     if (status != 'loaded') {
         $('#' + view_type).attr("status", "loaded");
@@ -215,9 +217,12 @@ function draw_chart(data) {
             // toDataURL function gets url of chart in type of jpeg image
             animation: {
                 onComplete: function() {
+                    // sets download jpg button
                     let time_link = document.getElementById(data['view_type']).toDataURL("image/jpeg");
-                    document.getElementById(data['view_type']+'-url').href = time_link;
-                    document.getElementById(data['view_type']+'-url').setAttribute('download', 'edits_over_time.jpg');
+                    document.getElementById(data['view_type']+'-jpg').href = time_link;
+                    document.getElementById(data['view_type']+'-jpg').setAttribute('download', 'edits_over_time.jpg');
+                    // sets download csv button
+                    document.getElementById(data['view_type']+'-csv').href = '/time_csv/?' + url_param + '&amp;view_type=' + data['view_type'] ;
                 }
             }
         }

--- a/hashtagsv2/settings/base.py
+++ b/hashtagsv2/settings/base.py
@@ -72,7 +72,6 @@ DATABASES = {
         'PASSWORD': os.environ['MYSQL_ROOT_PASSWORD'],
         'HOST': 'db',
         'PORT': '3306',
-        'OPTIONS': {'charset': 'utf8mb4'},
     }
 }
 

--- a/hashtagsv2/settings/base.py
+++ b/hashtagsv2/settings/base.py
@@ -72,6 +72,7 @@ DATABASES = {
         'PASSWORD': os.environ['MYSQL_ROOT_PASSWORD'],
         'HOST': 'db',
         'PORT': '3306',
+        'OPTIONS': {'charset': 'utf8mb4'},
     }
 }
 


### PR DESCRIPTION
with reference to [T239598](https://phabricator.wikimedia.org/T239598)
work don : 
- at first the user will be displayed the default view (best suitable).
- then the user can change the display as per his requirements.
- the AJAX request for another display is sent when user clicks the button

![dailyView](https://user-images.githubusercontent.com/43791665/73329786-e434c000-4284-11ea-9e28-d3f9cc936403.png)
![monthlyView](https://user-images.githubusercontent.com/43791665/73329787-e434c000-4284-11ea-993d-6b19e5e0b315.png)
![yearly View](https://user-images.githubusercontent.com/43791665/73329788-e4cd5680-4284-11ea-87ee-c62933a292c8.png)
