### PR TITLE
T207846 : Encode 4-byte unicode properly

### DIFF
--- a/hashtagsv2/settings/base.py
+++ b/hashtagsv2/settings/base.py
@@ -72,6 +72,7 @@ DATABASES = {
         'PASSWORD': os.environ['MYSQL_ROOT_PASSWORD'],
         'HOST': 'db',
         'PORT': '3306',
+        'OPTIONS': {'charset': 'utf8mb4'},
     }
 }
 


### PR DESCRIPTION
with reference to [T207846 : Encode 4-byte unicode properly.](https://phabricator.wikimedia.org/T207846) 
added `'charset' : 'utf8mb4'` in database settings in settings/base.py
![Screenshot from 2020-01-30 11-43-48](https://user-images.githubusercontent.com/43791665/73332478-e00ca080-428c-11ea-8642-dc3d7b56d36c.png)

