### PR TITLE
replace external assets url with proxy url

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This tool is also running on a Horizon VPS instance, rather than Toolforge, to e
 
 To set the tool up for local development, you will need:
 
-* [Docker](https://docs.docker.com/engine/install)
+* [Docker](https://www.docker.com)
 * [Docker Compose](https://docs.docker.com/compose/install)
 
 If you are installing Docker on Mac or Windows, Docker Compose is likely already included in your install.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This tool is also running on a Horizon VPS instance, rather than Toolforge, to e
 
 To set the tool up for local development, you will need:
 
-* [Docker](https://www.docker.com)
+* [Docker](https://docs.docker.com/engine/install)
 * [Docker Compose](https://docs.docker.com/compose/install)
 
 If you are installing Docker on Mac or Windows, Docker Compose is likely already included in your install.

--- a/hashtagsv2/graphs/templates/graphs/graph.html
+++ b/hashtagsv2/graphs/templates/graphs/graph.html
@@ -4,8 +4,8 @@
 {% load i18n %}
 
 {% block content %}
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.0/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.min.js"></script>
+<script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/3.4.0/jquery.min.js"></script>
+<script src="https://tools-static.wmflabs.org/cdnjs/ajax//libs/Chart.js/2.8.0/Chart.min.js"></script>
 <div class="container">
     <form id="tag-search">
         <div class="row">


### PR DESCRIPTION
To comply with WIkimedia's privacy policy, using the tool mentioned at https://wikitech.wikimedia.org/wiki/Help:Toolforge/Web#External_assets to load external assets.