### PR TITLE
Make collect_hashtags.py more reliable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ After cloning the repository, copy `template.env` to `.env` and start the tool b
 
 The `-d` option will allow you to run in detached mode.
 
-You should now be able to access the tool on `127.0.0.1`.
+You should now be able to access the tool in your browser on `http://localhost`.
 
 When the tool is first run the scripts container will fail because migrations haven't finished running yet. There are solutions to this that <a href="https://phabricator.wikimedia.org/T207277">will be implemented eventually</a>.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
    build:
     context: .
     dockerfile: 'Dockerfile-scripts'
+   restart: unless-stopped
    networks:
      - main
    env_file:

--- a/scripts/collect_hashtags.py
+++ b/scripts/collect_hashtags.py
@@ -24,7 +24,20 @@ else:
 if len(sys.argv) > 1 and sys.argv[1] == 'nohistorical':
     url = base_stream_url
 
-for event in EventSource(url):
+for event in EventSource(
+        url,
+        # The retry argument sets the delay between retries in milliseconds.
+        # We're setting this to 5 minutes.
+        # There's no way to set the max_retries value with this library,
+        # but since it depends upon requests, which in turn uses urllib3
+        # by default, we get a default max_retries value of 3.
+        retry=300000,
+        # The timeout argument gets passed to requests.get.
+        # An integer value sets connect (socket connect) and
+        # read (time to first byte / since last byte) timeout values.
+        # A tuple value sets each respective value independently.
+        # https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
+        timeout=(3.05, 30)):
     if event.event == 'message':
         try:
             change = json.loads(event.data)


### PR DESCRIPTION
This is very inspired on similar work in https://github.com/WikipediaLibrary/externallinks/pull/50.

The intention here is to allow collect_hashtags.py to retry after a disconnect, while also tuning the disconnect detection. Additionally, that script should pretty much always run, so we configure Docker to restart it if it crashes.