### PR TITLE
Fix logic for extracting media types from imageinfo response.

### DIFF
--- a/scripts/collect_hashtags.py
+++ b/scripts/collect_hashtags.py
@@ -57,8 +57,8 @@ def query_media_types(session, media_filenames):
                 if 'mediatype' not in m['imageinfo'][0]:
                     # Probably filehidden?
                     continue
+            media_types.add(m['imageinfo'][0]['mediatype'])
             if 'continue' in result:
-                media_types.add(m['imageinfo'][0]['mediatype'])
                 iistart = result['continue']['iistart']
             else:
                 break


### PR DESCRIPTION
Previously, we would incorrectly fail to get the media types unless the response was paginated.