### PR TITLE
Use the media types from all media added in an edit.

### DIFF
--- a/scripts/collect_hashtags.py
+++ b/scripts/collect_hashtags.py
@@ -57,7 +57,7 @@ def query_media_types(session, media_filenames):
                 if 'mediatype' not in m['imageinfo'][0]:
                     # Probably filehidden?
                     continue
-            media_types.add(m['imageinfo'][0]['mediatype'])
+                media_types.add(m['imageinfo'][0]['mediatype'])
             if 'continue' in result:
                 iistart = result['continue']['iistart']
             else:


### PR DESCRIPTION
Due to bad indentation, we'd previously use only the type of the last media added in an edit to find out whether it adds images or videos.

This is mostly not a problem, except if an edit added _both_ an image and a video, we'd fail to recognize that and record only the image or only the video, depending on which is returned last by the API.

Sorry for yet another bug in this line - third time's the charm, right?