### PR TITLE
Fix some more low-hanging fruit for reliability, and add magic troubleshooting instructions.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
      - main
    env_file:
      - '.env'
+   cap_add:
+     - SYS_PTRACE
    depends_on:
      - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
      - "3306:3306"
    networks:
      - main
+   restart: unless-stopped
    command: ['mysqld', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
    healthcheck:
      test: ["CMD", "mysqladmin", "ping", "-h", "localhost","-phashtag"]

--- a/scripts/collect_hashtags.py
+++ b/scripts/collect_hashtags.py
@@ -9,6 +9,8 @@ import db
 
 import mwapi
 
+API_REQUEST_TIMEOUT_S = 10.0
+
 # An arbitrary limit to how many times we follow the "continue" response in
 # imageinfo requests. See https://github.com/WikipediaLibrary/hashtags/issues/64
 # for details.
@@ -17,7 +19,8 @@ MAX_IMAGEINFO_CONTINUES = 50
 @functools.lru_cache(maxsize=None)
 def get_wiki_session(domain):
     return mwapi.Session(
-        'https://{}/'.format(domain), 'hashtags')
+        'https://{}/'.format(domain), 'hashtags',
+        timeout = API_REQUEST_TIMEOUT_S)
 
 def query_media_in_revision(session, rev_id):
     images_args = {


### PR DESCRIPTION
When working on my SQL experiments, I found that I could reproduce the issue where collect_hashtags.py gets stuck sometimes.

To determine why, I finally figured out how to get a stack trace of a running script - the instructions are sort of arcane, but do seem to work reliably. If we get stuck again, it would be very helpful to use them and see a stack trace.

In my local runs, it turned out that the script was stuck querying the API to determine media changes, so let's add a timeout to that and see if it helps.

Finally, we should restart the db container if it fails. I don't know why it happens and don't actually think that's the reason for prod being stuck, but I've seen it locally a couple of times so it doesn't hurt to configure that.