### PR TITLE
Don't use HTML-encoded URLs for API calls.

### DIFF
--- a/hashtagsv2/graphs/templates/graphs/graph.html
+++ b/hashtagsv2/graphs/templates/graphs/graph.html
@@ -219,7 +219,6 @@
         </div>
     </div>
     <hr>
-    <script> var url_param = '{{ query_string }}'; </script>
     <script src="{% static 'js/graph.js' %}"></script>
     {% endif %}
 </div>

--- a/hashtagsv2/hashtags/static/js/graph.js
+++ b/hashtagsv2/hashtags/static/js/graph.js
@@ -12,6 +12,7 @@ url_string = window.location.href;
 var url = new URL(url_string);
 var project = url.searchParams.get("project");
 var user  = url.searchParams.get("user");
+var url_param = url.searchParams.toString();
 
 // Hide top projects section when filtering on it
 if (project!=="" && project!==null){


### PR DESCRIPTION
`{{ query_string }}` is an HTML-escaped string (e.g. `&amp;` instead of `&`).  This means that, in an URL like:

`/graph/?project=&startdate=2021-01-14&search_type=or&enddate=&user=&query=1Lib1Ref%2C+1lib1refCEE%2C+1bib1ref`

`{{ query_string }}` is:

`project=&amp;startdate=2021-01-14&amp;search_type=or&amp;enddate=&amp;user=&amp;query=1Lib1Ref%2C+1lib1refCEE%2C+1bib1ref`

Note how every parameter after the first ("project") is preceded by `&amp`. When this is used to construct an API query in the graphs page, this causes every parameter except for the first to be ignored, because it has a different name than what the server expects.