### PR TITLE
Skip edits with suppressed usernames

### DIFF
--- a/scripts/collect_hashtags.py
+++ b/scripts/collect_hashtags.py
@@ -148,6 +148,10 @@ for event in EventSource(
                     if 'id' not in change:
                         print("Couldn't find recent changes ID in data. Skipping.")
                         continue
+                    # Likely a suppressed username.
+                    if 'user' not in change:
+                        print("Couldn't find user in data. Skipping.")
+                        continue
                     if db.is_duplicate(hashtag, change['id']):
                         print("Skipped duplicate {hashtag} (rc_id = {id})".format(
                             hashtag=hashtag, id=change['id']))


### PR DESCRIPTION
**Phabricator:** [T358547](https://phabricator.wikimedia.org/T358547)

Likely as a result of recent changes in https://phabricator.wikimedia.org/T241178, edits with suppressed usernames no longer contain `user` data, which was causing the scripts container to crash out when encountering such an edit. This change causes us to simply skip these edits - they probably weren't constructive ones worth tracking anyway.